### PR TITLE
Export ConsoleFormat class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export interface ConsoleFormatOptions {
   inspectOptions?: InspectOptions
 }
 
-class ConsoleFormat {
+export class ConsoleFormat {
   private static readonly reSpaces = /^\s+/
   private static readonly reSpacesOrEmpty = /^(\s*)/
   private static readonly reColor = /\x1B\[\d+m/


### PR DESCRIPTION
If a user wants to change the formatting a bit, he has to completely
redefine (copy-paste) the current implementation. Though, he could
just inherit the ConsoleFormat class and override some of the methods or fields.
